### PR TITLE
Add variables to get associated NSURL and BookmarkData to FKPath

### DIFF
--- a/FileKitTests/FileKitTests.swift
+++ b/FileKitTests/FileKitTests.swift
@@ -146,6 +146,71 @@ class FileKitTests: XCTestCase {
         XCTAssertEqual(ps.parent, ps^)
     }
     
+    func testCurrent() {
+        XCTAssertNotNil(FKPath.Current)
+        
+        let oldCurrent = FKPath.Current
+        let newCurrent: FKPath = FKPath.UserTemporary
+
+        XCTAssertNotEqual(oldCurrent, newCurrent) // else there is no test
+        
+        FKPath.Current = newCurrent
+        XCTAssertEqual(FKPath.Current, newCurrent)
+        
+        FKPath.Current = oldCurrent
+        XCTAssertEqual(FKPath.Current, oldCurrent)
+    }
+    
+    func testVolumes() {
+        if let volumes = FKPath.Volumes() {
+            for volume in volumes {
+                XCTAssertNotNil("\(volume)")
+            }
+        }
+        else {
+             XCTFail("No volume")
+        }
+        if let volumes = FKPath.Volumes(.SkipHiddenVolumes) {
+            for volume in volumes {
+                XCTAssertNotNil("\(volume)")
+            }
+        }
+        else {
+            XCTFail("No visible volume")
+        }
+    }
+    
+    func testURL() {
+        let path: FKPath = FKPath.UserTemporary
+        XCTAssertNotNil(path.url)
+        
+        if let url = path.url {
+            if let pathFromUrl = FKPath(url: url) {
+                XCTAssertEqual(pathFromUrl, path)
+
+                let subPath = pathFromUrl + "test"
+                XCTAssertEqual(FKPath(url: url.URLByAppendingPathComponent("test")), subPath)
+            }
+            else {
+                XCTFail("Not able to create FKPath from URL")
+            }
+        }
+    }
+
+    func testBookmarkData() {
+        let path: FKPath = FKPath.UserTemporary
+        XCTAssertNotNil(path.bookmarkData)
+
+        if let bookmarkData = path.bookmarkData {
+            if let pathFromBookmarkData = FKPath(bookmarkData: bookmarkData) {
+                XCTAssertEqual(pathFromBookmarkData, path)
+            }
+            else {
+                XCTFail("Not able to create FKPath from Bookmark Data")
+            }
+        }
+    }
+
     // MARK: - FKTextFile
     
     let tf = FKTextFile(path: FKPath.UserDesktop + "filekit_test.txt")


### PR DESCRIPTION
Add an `init` with `NSURL` and one with BookmarkData to `FKPath`
Add static function to get `Volumes` to `FKPath`

Added some tests, also for current path

## URL
Because many foundation api use `NSURL`, this variable and init could help
Then many extension could be done to replace `NSURL` with `FKPath` on foundation classes
exemple: `NSSavePanel.URL`, `NSFileHandle`

## BookmarkData
Allow to keep access to a file after application restart by storying the `NSData`
Without that, access could have been no more granted

If `FKPath` was a class and not a struct to conform to `NSCoding` protocol we can archive this bookmark data like that :
```swift
extension FKPath: NSCoding {

    public init?(coder aDecoder: NSCoder) {
        if let bookmarkData = aDecoder.decodeObjectOfClass(NSData.self, forKey: "bookmarkKey") {
            self.init(bookmarkData: bookmarkData)
        } else {
            return nil
        }
    }
    
    public func encodeWithCoder(aCoder: NSCoder) {
        aCoder.encodeObject(bookmarkData, forKey: "bookmarkKey")
    }
}
```

