### PR TITLE
Add `touch` function to FKPath

### DIFF
--- a/FileKit.xcodeproj/project.pbxproj
+++ b/FileKit.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		52BF6BA91B992AD500F07E13 /* FKFileType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BF6BA71B992AD500F07E13 /* FKFileType.swift */; settings = {ASSET_TAGS = (); }; };
 		52BF6BB11B99322000F07E13 /* FKError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BF6BB01B99322000F07E13 /* FKError.swift */; settings = {ASSET_TAGS = (); }; };
 		52BF6BB21B99322000F07E13 /* FKError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BF6BB01B99322000F07E13 /* FKError.swift */; settings = {ASSET_TAGS = (); }; };
+		C404F01E1BC7CA7200EF9ED9 /* Date+FileKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = C404F01D1BC7CA7200EF9ED9 /* Date+FileKit.swift */; settings = {ASSET_TAGS = (); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -81,6 +82,7 @@
 		527612421BAEA3EE00503D0A /* FileKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FileKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		52BF6BA71B992AD500F07E13 /* FKFileType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FKFileType.swift; sourceTree = "<group>"; };
 		52BF6BB01B99322000F07E13 /* FKError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FKError.swift; sourceTree = "<group>"; };
+		C404F01D1BC7CA7200EF9ED9 /* Date+FileKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Date+FileKit.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -177,9 +179,18 @@
 			isa = PBXGroup;
 			children = (
 				5263A9061B96BA3D00635A93 /* FileKitTests.swift */,
+				C404F01F1BC7CD0500EF9ED9 /* Extensions */,
 				5263A9081B96BA3D00635A93 /* Info.plist */,
 			);
 			path = FileKitTests;
+			sourceTree = "<group>";
+		};
+		C404F01F1BC7CD0500EF9ED9 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				C404F01D1BC7CA7200EF9ED9 /* Date+FileKit.swift */,
+			);
+			name = Extensions;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -402,6 +413,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5263A9071B96BA3D00635A93 /* FileKitTests.swift in Sources */,
+				C404F01E1BC7CA7200EF9ED9 /* Date+FileKit.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FileKit/Core/FKError.swift
+++ b/FileKit/Core/FKError.swift
@@ -49,6 +49,8 @@ public enum FKError: ErrorType {
             return "Could not move file at \(fromPath) to \(toPath)"
         case let CopyFileFail(fromPath, toPath):
             return "Could not copy file from \(fromPath) to \(toPath)"
+        case let AttributesChangeFail(path):
+            return "Could not change file attrubutes at \(path)"
         }
     }
     
@@ -75,4 +77,7 @@ public enum FKError: ErrorType {
     
     /// A file could not be copied.
     case CopyFileFail(fromPath: FKPath, toPath: FKPath)
+
+    /// One or many attributes could not be changed.
+    case AttributesChangeFail(path: FKPath)
 }

--- a/FileKit/Core/FKPath.swift
+++ b/FileKit/Core/FKPath.swift
@@ -244,7 +244,26 @@ public struct FKPath: StringLiteralConvertible,
             throw FKError.CreateFileFail(path: self)
         }
     }
-    
+
+    /// Creates a file at path if not exist 
+    /// or update the modification date.
+    ///
+    /// Throws an error if the file cannot be created
+    /// or if modification date could not be modified.
+    ///
+    /// - Throws: `FKError.CreateFileFail` or `FKError.AttributesChangeFail`
+    ///
+    public func touch(updateModificationDate : Bool = true) throws {
+        if self.exists {
+            if updateModificationDate {
+                try setAttribute(NSFileModificationDate, value: NSDate())
+            }
+        }
+        else {
+            try createFile()
+        }
+    }
+
     /// Creates a directory at the path.
     ///
     /// Throws an error if the directory cannot be created.
@@ -325,6 +344,21 @@ public struct FKPath: StringLiteralConvertible,
     /// Returns the path's attributes.
     public var attributes: [String : AnyObject] {
         return (try? FKPath.FileManager.attributesOfItemAtPath(_path)) ?? [:]
+    }
+    
+    /// Modify attributes
+    private func setAttributes(attributes: [String : AnyObject]) throws {
+        do {
+            try FKPath.FileManager.setAttributes(attributes, ofItemAtPath: self._path)
+        }
+        catch {
+            throw FKError.AttributesChangeFail(path: self)
+        }
+    }
+    
+    // Modify one attribute
+    private func setAttribute(key: String, value : AnyObject) throws {
+        try setAttributes([key:value])
     }
 
     /// The creation date of the file at the path.

--- a/FileKitTests/Date+FileKit.swift
+++ b/FileKitTests/Date+FileKit.swift
@@ -1,0 +1,38 @@
+//
+//  Date.swift
+//  FileKitTest
+//
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2015 Nikolai Vazquez
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+public func ==(lhs: NSDate, rhs: NSDate) -> Bool {
+    return lhs === rhs || lhs.compare(rhs) == .OrderedSame
+}
+
+public func <(lhs: NSDate, rhs: NSDate) -> Bool {
+    return lhs.compare(rhs) == .OrderedAscending
+}
+
+extension NSDate: Comparable { }

--- a/FileKitTests/FileKitTests.swift
+++ b/FileKitTests/FileKitTests.swift
@@ -207,6 +207,38 @@ class FileKitTests: XCTestCase {
             }
         }
     }
+    
+    func testTouch() {
+        let path: FKPath = .UserTemporary + "filekit_test.touch"
+        do {
+            if path.exists {
+                try path.deleteFile()
+            }
+            XCTAssertFalse(path.exists)
+
+            try path.touch()
+            XCTAssertTrue(path.exists)
+            
+            guard let modificationDate = path.modificationDate else {
+                XCTFail("Failed to get modification date")
+                return
+            }
+            sleep(1)
+            try path.touch()
+            guard let newModificationDate = path.modificationDate else {
+                XCTFail("Failed to get modification date")
+                return
+            }
+            
+            XCTAssertTrue(modificationDate < newModificationDate)
+            
+        } catch let error as FKError {
+            XCTFail(error.message)
+        } catch {
+            XCTFail()
+        }
+    }
+    
 
     // MARK: - FKTextFile
     


### PR DESCRIPTION
touch = create or update modification date
test included

private method to change attributes, need some reflexion to expose it
- create a enum of attribute or not
- modify using the already created `var` (`modificationDate`, ..) but exception must be catch

Feel free to modify the `AttributesChangeFail` error name, maybe we could add the attributes keys 
(we could wait for methods which modify attributes for that)
