### PR TITLE
Add protocol `FKWritableConvertible`

### DIFF
--- a/FileKit/Core/FKDataType.swift
+++ b/FileKit/Core/FKDataType.swift
@@ -91,3 +91,23 @@ extension FKWritableToFile {
 
 }
 
+/// A type that can be converted to a FKWritable.
+public protocol FKWritableConvertible: FKWritable {
+    var fkWritable: FKWritable? {get}
+}
+
+extension FKWritableConvertible {
+
+    public func writeToPath(path: FKPath) throws {
+        try writeToPath(path, atomically: true)
+    }
+
+    public func writeToPath(path: FKPath, atomically useAuxiliaryFile: Bool) throws {
+        guard let writable =  self.fkWritable else {
+            throw FKError.WriteToFileFail(path: path)
+        }
+        try writable.writeToPath(path, atomically: useAuxiliaryFile)
+    }
+}
+
+

--- a/FileKit/Extensions/FKImageType.swift
+++ b/FileKit/Extensions/FKImageType.swift
@@ -36,11 +36,16 @@ import WatchKit
 public typealias FKImageType = UIImage
 #endif
 
-extension FKImageType: FKWritable {
+extension FKImageType: FKWritableConvertible {
 
-    // TODO: Implement writeToPath(_:atomically:)
-    public func writeToPath(path: FKPath, atomically useAuxiliaryFile: Bool) throws {
-        fatalError("\(__FUNCTION__) not implemented yet.")
+    public var fkWritable: FKWritable? {
+        #if os(OSX)
+        return self.TIFFRepresentation
+        #elseif os(iOS)
+        return UIImagePNGRepresentation(self)
+        #else
+        return UIImagePNGRepresentation(self)
+        #endif
     }
 
 }

--- a/FileKitTests/FileKitTests.swift
+++ b/FileKitTests/FileKitTests.swift
@@ -334,13 +334,15 @@ class FileKitTests: XCTestCase {
 
     // MARK: - FKImageType
 
-    let img = FKImageType()
+    let img = FKImageType(contentsOfURL: NSURL(string: "https://raw.githubusercontent.com/nvzqz/FileKit/assets/logo.png")!) ?? FKImageType()
 
     func testFKImageTypeWriting() {
         do {
-            let path: FKPath = .UserTemporary + "filekit_imagetest"
+            let path: FKPath = .UserTemporary + "filekit_imagetest.png"
             try img.writeToPath(path)
-        } catch {
+        } catch let error as FKError {
+            XCTFail(error.message)
+        } catch  {
             XCTFail()
         }
     }


### PR DESCRIPTION
Object could be used as `FKWritable` by returning an instance of it

This is just a reflexion, I try to implement image and make this experiment to factorise code maybe with other type which return some `NSData`or `NSDictionnary` (`NSUserDefaults. dictionaryRepresentation`, ...)

Feel free to close if you do not want to implement like this for image