### PR TITLE
Add FKCodingType for NSCoding compliant objects

### DIFF
--- a/FileKit.xcodeproj/project.pbxproj
+++ b/FileKit.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		52BF6BA91B992AD500F07E13 /* FKFileType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BF6BA71B992AD500F07E13 /* FKFileType.swift */; settings = {ASSET_TAGS = (); }; };
 		52BF6BB11B99322000F07E13 /* FKError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BF6BB01B99322000F07E13 /* FKError.swift */; settings = {ASSET_TAGS = (); }; };
 		52BF6BB21B99322000F07E13 /* FKError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BF6BB01B99322000F07E13 /* FKError.swift */; settings = {ASSET_TAGS = (); }; };
+		C404F0211BC7DA7F00EF9ED9 /* FKCodingType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C404F0201BC7DA7F00EF9ED9 /* FKCodingType.swift */; settings = {ASSET_TAGS = (); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -81,6 +82,7 @@
 		527612421BAEA3EE00503D0A /* FileKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FileKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		52BF6BA71B992AD500F07E13 /* FKFileType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FKFileType.swift; sourceTree = "<group>"; };
 		52BF6BB01B99322000F07E13 /* FKError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FKError.swift; sourceTree = "<group>"; };
+		C404F0201BC7DA7F00EF9ED9 /* FKCodingType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FKCodingType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -169,6 +171,7 @@
 				5204B7E51B96ADA100AA473F /* String+FileKit.swift */,
 				524D314E1BC78E44008B93D0 /* Foundation+FileKit.swift */,
 				524D315E1BC7A02A008B93D0 /* FKImageType.swift */,
+				C404F0201BC7DA7F00EF9ED9 /* FKCodingType.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -371,6 +374,7 @@
 				523C33991B9B764600AB70E4 /* FKDataType.swift in Sources */,
 				52BF6BB11B99322000F07E13 /* FKError.swift in Sources */,
 				52BF6BA81B992AD500F07E13 /* FKFileType.swift in Sources */,
+				C404F0211BC7DA7F00EF9ED9 /* FKCodingType.swift in Sources */,
 				524D31571BC79067008B93D0 /* FKArrayFile.swift in Sources */,
 				523C33A11B9B772A00AB70E4 /* FKFile.swift in Sources */,
 				523C337B1B9B68D600AB70E4 /* FKDictionaryFile.swift in Sources */,

--- a/FileKit/Extensions/FKCodingType.swift
+++ b/FileKit/Extensions/FKCodingType.swift
@@ -1,0 +1,53 @@
+//
+//  FKCodingType.swift
+//  FileKit
+//
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2015 Nikolai Vazquez
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+// A protocol to transform any NSCoding object to FKWritable
+// using the NSKeyedArchiver root
+public protocol FKCodingType : NSCoding, FKDataType {
+    
+}
+
+extension FKCodingType {
+
+    // Writable
+    public func writeToPath(path: FKPath) throws {
+        try writeToPath(path, atomically: true)
+    }
+    
+    public func writeToPath(path: FKPath, atomically useAuxiliaryFile: Bool) throws {
+        NSKeyedArchiver.archiveRootObject(self, toFile: path.rawValue)
+    }
+
+    // Readable
+    public init(contentsOfPath path: FKPath) throws {
+        guard let contents = NSKeyedUnarchiver.unarchiveObjectWithFile( path.rawValue) as? Self
+            else { throw FKError.ReadFromFileFail(path: path) }
+        self = contents
+    }
+}


### PR DESCRIPTION
An other experiment

Other way to do it is to use `NSKeyArchiver.archivedDataWithRootObject(rootObject: AnyObject) -> NSData` because there is `atomically` boolean
I could do it If you want
(And previous experiment `FKWritableConvertible` could also be used, but not necessary)

PS: I have a private "file" framework in swift 1.1 that I want to throw, that's why I make all this PR :wink:

