### PR TITLE
Add recursiveChildren var to get all subpath of the FKPath

### DIFF
--- a/FileKit/Core/FKPath.swift
+++ b/FileKit/Core/FKPath.swift
@@ -164,7 +164,15 @@ public struct FKPath: StringLiteralConvertible,
         }
         return []
     }
-    
+
+    /// The path's children paths in a recursive way.
+    public var recursiveChildren: [FKPath] {
+        if let paths = try? FKPath.FileManager.subpathsOfDirectoryAtPath(_path) {
+            return paths.map { self + FKPath($0) }
+        }
+        return []
+    }
+
     /// Initializes a path to "`/`".
     public init() {
         _path = "/"

--- a/FileKitTests/FileKitTests.swift
+++ b/FileKitTests/FileKitTests.swift
@@ -79,6 +79,12 @@ class FileKitTests: XCTestCase {
         let p: FKPath = "/Users"
         XCTAssertNotEqual(p.children, [])
     }
+    
+    func testPathRecursiveChildren() {
+        let p: FKPath = FKPath.UserTemporary
+        let children = p.recursiveChildren
+        XCTAssertNotEqual(children, [])
+    }
 
     func testPathAttributes() {
 


### PR DESCRIPTION
Maybe the name of the var recursiveChildren is not good
some idea
allChildren
fullChildren

you can copy code without merge PR if you want to change the name
