### PR TITLE
Feature uniquetempdir

### DIFF
--- a/FileKit/Core/FKOperators.swift
+++ b/FileKit/Core/FKOperators.swift
@@ -84,11 +84,18 @@ public func + (lhs: FKPath, rhs: FKPath) -> FKPath {
     }
 }
 
+public func + (lhs: FKPath, rhs: String) -> FKPath {
+   return lhs + FKPath(rhs)
+}
+
 /// Appends the right path to the left path.
 public func += (inout lhs: FKPath, rhs: FKPath) {
     lhs = lhs + rhs
 }
 
+public func += (inout lhs: FKPath, rhs: String) {
+    lhs = lhs + rhs
+}
 
 infix operator ->> {}
 

--- a/FileKit/Core/FKPath.swift
+++ b/FileKit/Core/FKPath.swift
@@ -626,6 +626,14 @@ extension FKPath {
         return FKPath(NSTemporaryDirectory())
     }
     
+    public static var ProcessTemporary: FKPath {
+        return FKPath.UserTemporary + NSProcessInfo.processInfo().globallyUniqueString
+    }
+    
+    public static var UniqueTemporary: FKPath {
+        return FKPath.ProcessTemporary + NSUUID().UUIDString
+    }
+    
     /// Returns the path to the user's caches directory.
     public static var UserCaches: FKPath {
         return pathInUserDomain(.CachesDirectory)

--- a/FileKitTests/FileKitTests.swift
+++ b/FileKitTests/FileKitTests.swift
@@ -238,7 +238,16 @@ class FileKitTests: XCTestCase {
             XCTFail()
         }
     }
-    
+
+    func testWellKnownDirectories() {
+        XCTAssertTrue(FKPath.UserHome.exists)
+        XCTAssertTrue(FKPath.UserTemporary.exists)
+        XCTAssertTrue(FKPath.UserCaches.exists)
+
+        XCTAssertFalse(FKPath.ProcessTemporary.exists)
+        XCTAssertFalse(FKPath.UniqueTemporary.exists)
+        XCTAssertNotEqual(FKPath.UniqueTemporary, FKPath.UniqueTemporary)
+    }
 
     // MARK: - FKTextFile
     


### PR DESCRIPTION
tmp dir is usefull to create temporary data

I add two operators with String when coding but maybe superfluous
I can remove them and code without them
