### PR TITLE
Add Swift 2.2 support + Fix Swift Linter warnings

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,13 @@
+# rule identifiers to exclude from running
+disabled_rules:
+- trailing_newline
+- trailing_whitespace
+- valid_docs
+
+# some rules are only opt-in
+opt_in_rules:
+- empty_count
+- missing_docs
+
+# configurable rules can be customized from this configuration file
+line_length: 200

--- a/FileKit.xcodeproj/project.pbxproj
+++ b/FileKit.xcodeproj/project.pbxproj
@@ -100,6 +100,8 @@
 		52B938CC1BF402ED001B7AEB /* ImageFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B938C81BF402ED001B7AEB /* ImageFile.swift */; };
 		52BF6BB11B99322000F07E13 /* FileKitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BF6BB01B99322000F07E13 /* FileKitError.swift */; };
 		52BF6BB21B99322000F07E13 /* FileKitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BF6BB01B99322000F07E13 /* FileKitError.swift */; };
+		82F4F2BD1CA95480002C8393 /* FileSystemWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F4F2BC1CA95480002C8393 /* FileSystemWatcher.swift */; };
+		82F4F2C01CA956F2002C8393 /* FileSystemEventStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F4F2BF1CA956F2002C8393 /* FileSystemEventStream.swift */; };
 		C404F01E1BC7CA7200EF9ED9 /* Date+FileKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = C404F01D1BC7CA7200EF9ED9 /* Date+FileKit.swift */; };
 		C4F7D01F1C08C0DA00EF359B /* FileSystemEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4F7D01E1C08C0DA00EF359B /* FileSystemEvent.swift */; };
 /* End PBXBuildFile section */
@@ -146,6 +148,9 @@
 		52B938B31BF3C3E5001B7AEB /* FileKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FileKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		52B938C81BF402ED001B7AEB /* ImageFile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageFile.swift; sourceTree = "<group>"; };
 		52BF6BB01B99322000F07E13 /* FileKitError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileKitError.swift; sourceTree = "<group>"; };
+		82F4F2BB1CA94DEC002C8393 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = .swiftlint.yml; sourceTree = "<group>"; };
+		82F4F2BC1CA95480002C8393 /* FileSystemWatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileSystemWatcher.swift; sourceTree = "<group>"; };
+		82F4F2BF1CA956F2002C8393 /* FileSystemEventStream.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileSystemEventStream.swift; sourceTree = "<group>"; };
 		C404F01D1BC7CA7200EF9ED9 /* Date+FileKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Date+FileKit.swift"; sourceTree = "<group>"; };
 		C4F7D01E1C08C0DA00EF359B /* FileSystemEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileSystemEvent.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -193,6 +198,7 @@
 		5204B7AC1B968B8600AA473F = {
 			isa = PBXGroup;
 			children = (
+				82F4F2BB1CA94DEC002C8393 /* .swiftlint.yml */,
 				5204B7B81B968B8600AA473F /* FileKit */,
 				5263A9051B96BA3D00635A93 /* FileKitTests */,
 				5204B7B71B968B8600AA473F /* Products */,
@@ -239,7 +245,7 @@
 				523C33981B9B764600AB70E4 /* DataType.swift */,
 				52BF6BB01B99322000F07E13 /* FileKitError.swift */,
 				523C33A61B9B894A00AB70E4 /* Operators.swift */,
-				C4F7D01E1C08C0DA00EF359B /* FileSystemEvent.swift */,
+				82F4F2BE1CA956D3002C8393 /* File System Event */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -267,6 +273,16 @@
 				5263A9081B96BA3D00635A93 /* Info.plist */,
 			);
 			path = FileKitTests;
+			sourceTree = "<group>";
+		};
+		82F4F2BE1CA956D3002C8393 /* File System Event */ = {
+			isa = PBXGroup;
+			children = (
+				C4F7D01E1C08C0DA00EF359B /* FileSystemEvent.swift */,
+				82F4F2BF1CA956F2002C8393 /* FileSystemEventStream.swift */,
+				82F4F2BC1CA95480002C8393 /* FileSystemWatcher.swift */,
+			);
+			name = "File System Event";
 			sourceTree = "<group>";
 		};
 		C404F01F1BC7CD0500EF9ED9 /* Extensions */ = {
@@ -560,9 +576,11 @@
 				52A017101C024D840045A9C8 /* NSString+FileKit.swift in Sources */,
 				52A017051C01AD6F0045A9C8 /* NSBundle+FileKit.swift in Sources */,
 				523C33991B9B764600AB70E4 /* DataType.swift in Sources */,
+				82F4F2BD1CA95480002C8393 /* FileSystemWatcher.swift in Sources */,
 				523C33A71B9B894A00AB70E4 /* Operators.swift in Sources */,
 				523C33781B9A7EFC00AB70E4 /* TextFile.swift in Sources */,
 				5263A8FC1B96B94D00635A93 /* Path.swift in Sources */,
+				82F4F2C01CA956F2002C8393 /* FileSystemEventStream.swift in Sources */,
 				52A016C41C013F3D0045A9C8 /* DirectoryEnumerator.swift in Sources */,
 				524D315F1BC7A02A008B93D0 /* Image+FileKit.swift in Sources */,
 				524D315B1BC79331008B93D0 /* DataFile.swift in Sources */,

--- a/FileKit/Core/DataFile.swift
+++ b/FileKit/Core/DataFile.swift
@@ -39,6 +39,7 @@ extension File where Data: NSData {
     ///                      described in `NSDataReadingOptions`.
     ///
     /// - Throws: `FileKitError.ReadFromFileFail`
+    /// - Returns: The data read from file.
     public func read(options: NSDataReadingOptions) throws -> Data {
         return try Data.readFromPath(path, options: options)
     }

--- a/FileKit/Core/DataType.swift
+++ b/FileKit/Core/DataType.swift
@@ -49,7 +49,7 @@ extension Readable {
     ///
     /// - Parameter path: The path being read from.
     ///
-    public init(contentsOfPath path: Path) throws {
+    public init(contentsOfPath path: Path) throws { // swiftlint:disable:this valid_docs
         self = try Self.readFromPath(path)
     }
 
@@ -81,7 +81,7 @@ extension Writable {
     ///
     /// - Parameter path: The path being written to.
     ///
-    public func writeToPath(path: Path) throws {
+    public func writeToPath(path: Path) throws { // swiftlint:disable:this valid_docs
         try writeToPath(path, atomically: true)
     }
 

--- a/FileKit/Core/DataType.swift
+++ b/FileKit/Core/DataType.swift
@@ -133,7 +133,7 @@ extension WritableToFile {
 public protocol WritableConvertible: Writable {
 
     /// The type that allows `Self` to be `Writable`.
-    typealias WritableType: Writable
+    associatedtype WritableType: Writable
 
     /// Allows `self` to be written to a path.
     var writable: WritableType { get }

--- a/FileKit/Core/DirectoryEnumerator.swift
+++ b/FileKit/Core/DirectoryEnumerator.swift
@@ -34,6 +34,8 @@ public struct DirectoryEnumerator: GeneratorType {
     private let _path: Path, _enumerator: NSDirectoryEnumerator?
 
     /// Creates a directory enumerator for the given path.
+    ///
+    /// - Parameter path: The path a directory enumerator to be created for.
     public init(path: Path) {
         _path = path
         _enumerator = NSFileManager().enumeratorAtPath(path.rawValue)

--- a/FileKit/Core/File.swift
+++ b/FileKit/Core/File.swift
@@ -66,6 +66,8 @@ public class File<Data: DataType>: Comparable {
     // MARK: - Initialization
 
     /// Initializes a file from a path.
+    ///
+    /// - Parameter path: The path a file to initialize from.
     public init(path: Path) {
         self.path = path
     }
@@ -75,6 +77,7 @@ public class File<Data: DataType>: Comparable {
     /// Reads the file and returns its data.
     ///
     /// - Throws: `FileKitError.ReadFromFileFail`
+    /// - Returns: The data read from file.
     public func read() throws -> Data {
         return try Data.readFromPath(path)
     }
@@ -116,6 +119,11 @@ public class File<Data: DataType>: Comparable {
     }
 
     /// Deletes the file.
+    ///
+    /// Throws an error if the file could not be deleted.
+    ///
+    /// - Throws: `FileKitError.DeleteFileFail`
+    ///
     public func delete() throws {
         try path.deleteFile()
     }
@@ -126,6 +134,7 @@ public class File<Data: DataType>: Comparable {
     ///
     /// Throws an error if the file cannot be moved.
     ///
+    /// - Parameter path: The path to move the file to.
     /// - Throws: `FileKitError.MoveFileFail`
     ///
     public func moveToPath(path: Path) throws {
@@ -138,6 +147,8 @@ public class File<Data: DataType>: Comparable {
     /// Throws an error if the file could not be copied or if a file already
     /// exists at the destination path.
     ///
+    ///
+    /// - Parameter path: The path to copy the file to.
     /// - Throws: `FileKitError.FileDoesNotExist`, `FileKitError.CopyFileFail`
     ///
     public func copyToPath(path: Path) throws {
@@ -152,6 +163,8 @@ public class File<Data: DataType>: Comparable {
     /// If the path already exists and _is_ a directory, the link will be made
     /// to `self` in that directory.
     ///
+    ///
+    /// - Parameter path: The path to symlink the file to.
     /// - Throws:
     ///     `FileKitError.FileDoesNotExist`,
     ///     `FileKitError.CreateSymlinkFail`

--- a/FileKit/Core/FilePermissions.swift
+++ b/FileKit/Core/FilePermissions.swift
@@ -61,11 +61,17 @@ public struct FilePermissions: OptionSetType, CustomStringConvertible {
     }
 
     /// Creates a set of file permissions.
+    ///
+    /// - Parameter rawValue: The raw value to initialize from.
+    ///
     public init(rawValue: Int) {
         self.rawValue = rawValue
     }
 
     /// Creates a set of permissions for the file at `path`.
+    ///
+    /// - Parameter path: The path to the file to create a set of persmissions for.
+    ///
     public init(forPath path: Path) {
         var permissions = FilePermissions(rawValue: 0)
         if path.isReadable { permissions.unionInPlace(.Read) }
@@ -75,6 +81,8 @@ public struct FilePermissions: OptionSetType, CustomStringConvertible {
     }
 
     /// Creates a set of permissions for `file`.
+    ///
+    /// - Parameter file: The file to create a set of persmissions for.
     public init<Data: DataType>(forFile file: File<Data>) {
         self.init(forPath: file.path)
     }

--- a/FileKit/Core/FileProtection.swift
+++ b/FileKit/Core/FileProtection.swift
@@ -48,6 +48,9 @@ public enum FileProtection: String {
     case CompleteUntilFirstUserAuthentication
 
     /// Initializes `self` from a file protection value.
+    ///
+    /// - Parameter rawValue: The raw value to initialize from.
+    ///
     public init?(rawValue: String) {
         switch rawValue {
         case NSFileProtectionNone:

--- a/FileKit/Core/FileSystemEvent.swift
+++ b/FileKit/Core/FileSystemEvent.swift
@@ -44,7 +44,7 @@ public struct FileSystemEvent {
     // MARK: - Properties
 
     /// The ID of the event.
-    public var id: FSEventStreamEventId
+    public var id: FSEventStreamEventId // swiftlint:disable:this variable_name
 
     /// The path for the event.
     public var path: Path
@@ -59,6 +59,11 @@ extension Path {
     // MARK: - Watching
 
     /// Watches a path for filesystem events and handles them in the callback.
+    ///
+    /// - Parameter latency: The latency in seconds.
+    /// - Parameter queue: The queue to be run within.
+    /// - Parameter callback: The callback to handle events.
+    /// - Returns: The `FileSystemWatcher` object.
     public func watch(latency: NSTimeInterval = 0, queue: dispatch_queue_t = dispatch_get_main_queue(), callback: (FileSystemEvent) -> Void) -> FileSystemWatcher {
         let watcher = FileSystemWatcher(paths: [self], latency: latency, queue: queue, callback: callback)
         watcher.watch()
@@ -73,6 +78,11 @@ extension SequenceType where Self.Generator.Element == Path {
 
     /// Watches the sequence of paths for filesystem events and handles them in
     /// the callback.
+    ///
+    /// - Parameter latency: The latency in seconds.
+    /// - Parameter queue: The queue to be run within.
+    /// - Parameter callback: The callback to handle events.
+    /// - Returns: The `FileSystemWatcher` object.
     public func watch(latency: NSTimeInterval = 0, queue: dispatch_queue_t = dispatch_get_main_queue(), callback: (FileSystemEvent) -> Void) -> FileSystemWatcher {
         let watcher = FileSystemWatcher(paths: Array(self), latency: latency, queue: queue, callback: callback)
         watcher.watch()
@@ -84,7 +94,7 @@ extension SequenceType where Self.Generator.Element == Path {
 
 
 /// A set of fileystem event flags.
-public struct FileSystemEventFlags : OptionSetType, CustomStringConvertible, CustomDebugStringConvertible {
+public struct FileSystemEventFlags: OptionSetType, CustomStringConvertible, CustomDebugStringConvertible {
 
     // MARK: - Options
 
@@ -189,7 +199,7 @@ public struct FileSystemEventFlags : OptionSetType, CustomStringConvertible, Cus
 
     /// An array of all of the flags.
     public static var allFlags: [FileSystemEventFlags] = {
-        var array: [FileSystemEventFlags] = [
+        var array: [FileSystemEventFlags] = [ // swiftlint:disable comma
             .None,              .MustScanSubDirs,       .UserDropped,
             .KernelDropped,     .EventIdsWrapped,       .HistoryDone,
             .RootChanged,       .Mount,                 .Unmount,
@@ -197,7 +207,7 @@ public struct FileSystemEventFlags : OptionSetType, CustomStringConvertible, Cus
             .ItemModified,      .ItemFinderInfoMod,     .ItemChangeOwner,
             .ItemXattrMod,      .ItemIsFile,            .ItemIsDir,
             .ItemIsSymlink,     .OwnEvent
-        ]
+        ] // swiftlint:enable comma
         if #available(iOS 9, OSX 10.10, *) {
             array += [.ItemIsHardlink, .ItemIsLastHardlink ]
         }
@@ -206,7 +216,7 @@ public struct FileSystemEventFlags : OptionSetType, CustomStringConvertible, Cus
 
     /// The names of all of the flags.
     public static let allFlagNames: [String] = {
-        var array: [String] = [
+        var array: [String] = [ // swiftlint:disable comma
             "None",             "MustScanSubDirs",      "UserDropped",
             "KernelDropped",    "EventIdsWrapped",      "HistoryDone",
             "RootChanged",      "Mount",                "Unmount",
@@ -214,7 +224,7 @@ public struct FileSystemEventFlags : OptionSetType, CustomStringConvertible, Cus
             "ItemModified",     "ItemFinderInfoMod",    "ItemChangeOwner",
             "ItemXattrMod",     "ItemIsFile",           "ItemIsDir",
             "ItemIsSymlink",    "OwnEvent",
-        ]
+        ] // swiftlint:enable comma
         if #available(iOS 9, OSX 10.10, *) {
             array += ["ItemIsHardlink", "ItemIsLastHardlink"]
         }
@@ -230,9 +240,9 @@ public struct FileSystemEventFlags : OptionSetType, CustomStringConvertible, Cus
     public var description: String {
         var result = ""
         for (index, element) in FileSystemEventFlags.allFlags.enumerate() {
-            if self.contains(element){
+            if self.contains(element) {
                 let name = FileSystemEventFlags.allFlagNames[index]
-                result += result.isEmpty ? "\(name)" : ", \(name)"
+                result += result.isEmpty ? "\(name)": ", \(name)"
             }
         }
         return String(self.dynamicType) + "[\(result)]"
@@ -242,9 +252,9 @@ public struct FileSystemEventFlags : OptionSetType, CustomStringConvertible, Cus
     public var debugDescription: String {
         var result = ""
         for (index, element) in FileSystemEventFlags.allFlags.enumerate() {
-            if self.contains(element){
+            if self.contains(element) {
                 let name = FileSystemEventFlags.allFlagNames[index] + "(\(element.rawValue))"
-                result += result.isEmpty ? "\(name)" : ", \(name)"
+                result += result.isEmpty ? "\(name)": ", \(name)"
             }
         }
         return String(self.dynamicType) + "[\(result)]"
@@ -253,13 +263,15 @@ public struct FileSystemEventFlags : OptionSetType, CustomStringConvertible, Cus
     // MARK: - Initialization
 
     /// Creates a set of event stream flags from a raw value.
+    ///
+    /// - Parameter rawValue: The raw value to initialize from.
     public init(rawValue: Int) { self.rawValue = rawValue }
 
 }
 
 
 /// Flags for creating an event stream.
-public struct FileSystemEventStreamCreateFlags : OptionSetType, CustomStringConvertible, CustomDebugStringConvertible {
+public struct FileSystemEventStreamCreateFlags: OptionSetType, CustomStringConvertible, CustomDebugStringConvertible {
 
     // MARK: - Options
 
@@ -300,24 +312,24 @@ public struct FileSystemEventStreamCreateFlags : OptionSetType, CustomStringConv
     public let rawValue: Int
 
     /// A textual representation of `self`.
-    public var description : String {
+    public var description: String {
         var result = ""
         for (index, element) in FileSystemEventStreamCreateFlags.allFlags.enumerate() {
-            if self.contains(element){
+            if self.contains(element) {
                 let name = FileSystemEventStreamCreateFlags.allFlagNames[index]
-                result += result.isEmpty ? "\(name)" : ", \(name)"
+                result += result.isEmpty ? "\(name)": ", \(name)"
             }
         }
         return String(self.dynamicType) + "[\(result)]"
     }
 
     /// A textual representation of `self`, suitable for debugging.
-    public var debugDescription : String {
+    public var debugDescription: String {
         var result = ""
         for (index, element) in FileSystemEventStreamCreateFlags.allFlags.enumerate() {
-            if self.contains(element){
+            if self.contains(element) {
                 let name = FileSystemEventStreamCreateFlags.allFlagNames[index] + "(\(element.rawValue))"
-                result += result.isEmpty ? "\(name)" : ", \(name)"
+                result += result.isEmpty ? "\(name)": ", \(name)"
             }
         }
         return String(self.dynamicType) + "[\(result)]"
@@ -326,266 +338,10 @@ public struct FileSystemEventStreamCreateFlags : OptionSetType, CustomStringConv
     // MARK: - Initialization
 
     /// Creates a set of event stream creation flags from a raw value.
+    ///
+    /// - Parameter rawValue: The raw value to initialize from.
     public init(rawValue: Int) { self.rawValue = rawValue }
 
-}
-
-
-/// A filesystem event stream.
-private struct FileSystemEventStream : RawRepresentable {
-
-    /// The raw FSEventStreamRef value of `self`.
-    var rawValue: FSEventStreamRef
-
-    /// Schedules the stream on the specified run loop.
-    func scheduleWithRunLoop(runLoop: CFRunLoopRef, runLoopMode: CFStringRef) {
-        FSEventStreamScheduleWithRunLoop(rawValue, runLoop, runLoopMode)
-    }
-
-    /// Invalidates the stream.
-    func invalidate() {
-        FSEventStreamInvalidate(rawValue)
-    }
-
-    /// Registers the stream.
-    func start() {
-        FSEventStreamStart(rawValue)
-    }
-
-    /// Unregisters the stream.
-    func stop() {
-        FSEventStreamStop(rawValue)
-    }
-
-    /// Removes the stream from the specified run loop.
-    func unscheduleFromRunLoop(runLoop: CFRunLoopRef, runLoopMode: CFStringRef) {
-        FSEventStreamUnscheduleFromRunLoop(rawValue, runLoop, runLoopMode)
-    }
-
-    /// Schedules the stream on the specified dispatch queue
-    func setDispatchQueue(queue: dispatch_queue_t) {
-        FSEventStreamSetDispatchQueue(rawValue, queue)
-    }
-
-    /// Decrements the FSEventStreamRef's refcount.
-    func release() {
-        FSEventStreamRelease(rawValue)
-    }
-
-    /// Asks the FS Events service to flush out any events that have occurred
-    /// but have not yet been delivered, due to the latency parameter that was
-    /// supplied when the stream was created. This flushing occurs
-    /// asynchronously.
-    func flushAsync() {
-        FSEventStreamFlushAsync(rawValue)
-    }
-
-    /// Asks the FS Events service to flush out any events that have occurred
-    /// but have not yet been delivered, due to the latency parameter that was
-    /// supplied when the stream was created. This flushing occurs
-    /// synchronously.
-    func flushSync() {
-        FSEventStreamFlushSync(rawValue)
-    }
-
-    /// Prints a description of the stream to stderr.
-    func show() {
-        FSEventStreamShow(rawValue)
-    }
-
-    /// The dev_t for a device-relative stream, otherwise 0.
-    func deviceBeingWatched() -> dev_t {
-        return FSEventStreamGetDeviceBeingWatched(rawValue)
-    }
-
-    /// The sinceWhen attribute of the stream.
-    var lastEventId: FSEventStreamEventId {
-        return FSEventStreamGetLatestEventId(rawValue)
-    }
-}
-
-
-/// Watches a given set of paths and runs a callback per event.
-public class FileSystemWatcher {
-
-    // MARK: - Private Static Properties
-
-    /// The event stream callback for when events occur.
-    private static let eventCallback: FSEventStreamCallback = {
-        (stream: ConstFSEventStreamRef,
-        contextInfo: UnsafeMutablePointer<Void>,
-        numEvents: Int,
-        eventPaths: UnsafeMutablePointer<Void>,
-        eventFlags: UnsafePointer<FSEventStreamEventFlags>,
-        eventIds: UnsafePointer<FSEventStreamEventId>) in
-
-        defer {
-            watcher.lastEventId = eventIds[numEvents - 1]
-        }
-
-        FileSystemWatcher.log("Callback Fired")
-
-        let watcher: FileSystemWatcher = unsafeBitCast(contextInfo, FileSystemWatcher.self)
-        guard let paths = unsafeBitCast(eventPaths, NSArray.self) as? [String] else {
-            return
-        }
-
-        for index in 0..<numEvents {
-            let id = eventIds[index]
-            let path = paths[index]
-            let flags = eventFlags[index]
-
-            let event = FileSystemEvent(
-                id: id,
-                path: Path(path),
-                flags: FileSystemEventFlags(rawValue: Int(flags)))
-            watcher.processEvent(event)
-        }
-    }
-
-    // MARK: - Properties
-
-    /// The paths being watched.
-    public let paths: [Path]
-
-    /// How often the watcher updates.
-    public let latency: CFTimeInterval
-
-    /// The queue for the watcher.
-    public let queue: dispatch_queue_t?
-
-    /// The flags used to create the watcher.
-    public let flags: FileSystemEventStreamCreateFlags
-
-    /// The run loop mode for the watcher.
-    public var runLoopMode: CFStringRef = kCFRunLoopDefaultMode
-
-    /// The run loop for the watcher.
-    public var runLoop: CFRunLoop = CFRunLoopGetMain()
-
-    /// The callback for filesystem events.
-    private let callback: (FileSystemEvent) -> Void
-
-    /// The last event ID for the watcher.
-    public private(set) var lastEventId: FSEventStreamEventId
-
-    /// Whether or not the watcher has started yet.
-    private var started = false
-
-    /// The event stream for the watcher.
-    private var stream: FileSystemEventStream?
-    
-    // MARK: - Initialization
-
-    /// Creates a watcher for the given paths.
-    public init(paths: [Path],
-        sinceWhen: FSEventStreamEventId = FileSystemEvent.NowEventId,
-        flags: FileSystemEventStreamCreateFlags = [.UseCFTypes, .FileEvents],
-        latency: CFTimeInterval = 0,
-        queue: dispatch_queue_t? = nil,
-        callback: (FileSystemEvent) -> Void
-    ) {
-        self.lastEventId = sinceWhen
-        self.paths       = paths
-        self.flags       = flags
-        self.latency     = latency
-        self.queue       = queue
-        self.callback    = callback
-    }
-
-    // MARK: - Deinitialization
-    
-    deinit {
-        self.close()
-    }
-    
-    // MARK: - Private Methods
-
-    /// Processes the event by logging it and then running the callback.
-    private func processEvent(event: FileSystemEvent) {
-        FileSystemWatcher.log("\t\(event.id) - \(event.flags) - \(event.path)")
-        self.callback(event)
-    }
-
-    /// Prints the message when in debug mode.
-    private static func log(message: String) {
-        #if DEBUG
-            print(message)
-        #endif
-    }
-    
-    // MARK: - Methods
-    
-    // Start watching by creating the stream
-    /// Starts watching.
-    public func watch() {
-        guard started == false else { return }
-        
-        var context = FSEventStreamContext(
-            version: 0,
-            info: nil,
-            retain: nil,
-            release: nil,
-            copyDescription: nil
-        )
-        // add self into context
-        context.info = UnsafeMutablePointer<Void>(unsafeAddressOf(self))
-        
-        let streamRef = FSEventStreamCreate(
-            kCFAllocatorDefault,
-            FileSystemWatcher.eventCallback,
-            &context,
-            paths.map{$0.rawValue},
-            // since when
-            lastEventId,
-            // how long to wait after an event occurs before forwarding it
-            latency,
-            UInt32(flags.rawValue)
-        )
-        stream = FileSystemEventStream(rawValue: streamRef)
-        
-        stream?.scheduleWithRunLoop(runLoop, runLoopMode: runLoopMode)
-        if let q = queue {
-            stream?.setDispatchQueue(q)
-        }
-        stream?.start()
-        
-        started = true
-    }
-    
-    // Stops, invalidates and releases the stream
-    /// Closes the watcher.
-    public func close() {
-        guard started == true else { return }
-        
-        stream?.stop()
-        stream?.invalidate()
-        stream?.release()
-        stream = nil
-        
-        started = false
-    }
-    
-    /// Requests that the fseventsd daemon send any events it has already
-    /// buffered (via the latency parameter).
-    ///
-    /// This occurs asynchronously; clients will not have received all the
-    /// callbacks by the time this call returns to them.
-    public func flushAsync() {
-        stream?.flushAsync()
-    }
-    
-    /// Requests that the fseventsd daemon send any events it has already
-    /// buffered (via the latency). Then runs the runloop in its private mode
-    /// till all events that have occurred have been reported (via the client's
-    /// callback).
-    ///
-    /// This occurs synchronously; clients will have received all the callbacks
-    /// by the time this call returns to them.
-    public func flushSync() {
-        stream?.flushSync()
-    }
-    
 }
 
 #endif

--- a/FileKit/Core/FileSystemEventStream.swift
+++ b/FileKit/Core/FileSystemEventStream.swift
@@ -1,0 +1,117 @@
+//
+//  FileSystemEvent.swift
+//  FileKit
+//
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2015-2016 Nikolai Vazquez
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+#if os(OSX)
+    
+    
+/// A filesystem event stream.
+private struct FileSystemEventStream: RawRepresentable {
+    
+    /// The raw FSEventStreamRef value of `self`.
+    var rawValue: FSEventStreamRef
+    
+    /// Schedules the stream on the specified run loop.
+    ///
+    /// - Parameter runLoop: The run loop.
+    /// - Parameter runLoopMode: The run loop mode.
+    func scheduleWithRunLoop(runLoop: CFRunLoopRef, runLoopMode: CFStringRef) {
+        FSEventStreamScheduleWithRunLoop(rawValue, runLoop, runLoopMode)
+    }
+    
+    /// Invalidates the stream.
+    func invalidate() {
+        FSEventStreamInvalidate(rawValue)
+    }
+    
+    /// Registers the stream.
+    func start() {
+        FSEventStreamStart(rawValue)
+    }
+    
+    /// Unregisters the stream.
+    func stop() {
+        FSEventStreamStop(rawValue)
+    }
+    
+    /// Removes the stream from the specified run loop.
+    ///
+    /// - Parameter runLoop: The run loop.
+    /// - Parameter runLoopMode: The run loop mode.
+    func unscheduleFromRunLoop(runLoop: CFRunLoopRef, runLoopMode: CFStringRef) {
+        FSEventStreamUnscheduleFromRunLoop(rawValue, runLoop, runLoopMode)
+    }
+    
+    /// Schedules the stream on the specified dispatch queue
+    ///
+    /// - Parameter queue: The queue to be run within.
+    func setDispatchQueue(queue: dispatch_queue_t) {
+        FSEventStreamSetDispatchQueue(rawValue, queue)
+    }
+    
+    /// Decrements the FSEventStreamRef's refcount.
+    func release() {
+        FSEventStreamRelease(rawValue)
+    }
+    
+    /// Asks the FS Events service to flush out any events that have occurred
+    /// but have not yet been delivered, due to the latency parameter that was
+    /// supplied when the stream was created. This flushing occurs
+    /// asynchronously.
+    func flushAsync() {
+        FSEventStreamFlushAsync(rawValue)
+    }
+    
+    /// Asks the FS Events service to flush out any events that have occurred
+    /// but have not yet been delivered, due to the latency parameter that was
+    /// supplied when the stream was created. This flushing occurs
+    /// synchronously.
+    func flushSync() {
+        FSEventStreamFlushSync(rawValue)
+    }
+    
+    /// Prints a description of the stream to stderr.
+    func show() {
+        FSEventStreamShow(rawValue)
+    }
+    
+    /// The dev_t for a device-relative stream, otherwise 0.
+    ///
+    /// - Returns: The dev_t for a device-relative stream or 0.
+    func deviceBeingWatched() -> dev_t {
+        return FSEventStreamGetDeviceBeingWatched(rawValue)
+    }
+    
+    /// The sinceWhen attribute of the stream.
+    var lastEventId: FSEventStreamEventId {
+        return FSEventStreamGetLatestEventId(rawValue)
+    }
+}
+
+
+#endif

--- a/FileKit/Core/FileSystemEventStream.swift
+++ b/FileKit/Core/FileSystemEventStream.swift
@@ -31,7 +31,7 @@ import Foundation
     
     
 /// A filesystem event stream.
-private struct FileSystemEventStream: RawRepresentable {
+internal struct FileSystemEventStream: RawRepresentable {
     
     /// The raw FSEventStreamRef value of `self`.
     var rawValue: FSEventStreamRef

--- a/FileKit/Core/FileSystemWatcher.swift
+++ b/FileKit/Core/FileSystemWatcher.swift
@@ -1,0 +1,235 @@
+//
+//  FileSystemWatcher.swift
+//  FileKit
+//
+//  Created by Cihat Gündüz on 28.03.16.
+//  Copyright © 2016 Nikolai Vazquez. All rights reserved.
+//
+
+//
+//  FileSystemEvent.swift
+//  FileKit
+//
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2015-2016 Nikolai Vazquez
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+#if os(OSX)
+    
+    
+/// Watches a given set of paths and runs a callback per event.
+public class FileSystemWatcher {
+    
+    // MARK: - Private Static Properties
+    
+    /// The event stream callback for when events occur.
+    private static let eventCallback: FSEventStreamCallback = {
+        (stream: ConstFSEventStreamRef,
+        contextInfo: UnsafeMutablePointer<Void>,
+        numEvents: Int,
+        eventPaths: UnsafeMutablePointer<Void>,
+        eventFlags: UnsafePointer<FSEventStreamEventFlags>,
+        eventIds: UnsafePointer<FSEventStreamEventId>) in
+        
+        defer {
+            watcher.lastEventId = eventIds[numEvents - 1]
+        }
+        
+        FileSystemWatcher.log("Callback Fired")
+        
+        let watcher: FileSystemWatcher = unsafeBitCast(contextInfo, FileSystemWatcher.self)
+        guard let paths = unsafeBitCast(eventPaths, NSArray.self) as? [String] else {
+            return
+        }
+        
+        for index in 0..<numEvents {
+            let id = eventIds[index]
+            let path = paths[index]
+            let flags = eventFlags[index]
+            
+            let event = FileSystemEvent(
+                id: id,
+                path: Path(path),
+                flags: FileSystemEventFlags(rawValue: Int(flags)))
+            watcher.processEvent(event)
+        }
+    }
+    
+    // MARK: - Properties
+    
+    /// The paths being watched.
+    public let paths: [Path]
+    
+    /// How often the watcher updates.
+    public let latency: CFTimeInterval
+    
+    /// The queue for the watcher.
+    public let queue: dispatch_queue_t?
+    
+    /// The flags used to create the watcher.
+    public let flags: FileSystemEventStreamCreateFlags
+    
+    /// The run loop mode for the watcher.
+    public var runLoopMode: CFStringRef = kCFRunLoopDefaultMode
+    
+    /// The run loop for the watcher.
+    public var runLoop: CFRunLoop = CFRunLoopGetMain()
+    
+    /// The callback for filesystem events.
+    private let callback: (FileSystemEvent) -> Void
+    
+    /// The last event ID for the watcher.
+    public private(set) var lastEventId: FSEventStreamEventId
+    
+    /// Whether or not the watcher has started yet.
+    private var started = false
+    
+    /// The event stream for the watcher.
+    private var stream: FileSystemEventStream?
+    
+    // MARK: - Initialization
+    
+    /// Creates a watcher for the given paths.
+    ///
+    /// - Parameter paths: The paths.
+    /// - Parameter sinceWhen: The date to start at.
+    /// - Parameter flags: The create flags.
+    /// - Parameter latency: The latency.
+    /// - Parameter queue: The queue to be run within.
+    /// - Parameter callback: The callback to be called on changes.
+    public init(paths: [Path],
+                sinceWhen: FSEventStreamEventId = FileSystemEvent.NowEventId,
+                flags: FileSystemEventStreamCreateFlags = [.UseCFTypes, .FileEvents],
+                latency: CFTimeInterval = 0,
+                queue: dispatch_queue_t? = nil,
+                callback: (FileSystemEvent) -> Void
+        ) {
+        self.lastEventId = sinceWhen
+        self.paths       = paths
+        self.flags       = flags
+        self.latency     = latency
+        self.queue       = queue
+        self.callback    = callback
+    }
+    
+    // MARK: - Deinitialization
+    
+    deinit {
+        self.close()
+    }
+    
+    // MARK: - Private Methods
+    
+    /// Processes the event by logging it and then running the callback.
+    ///
+    /// - Parameter event: The file system event to be logged.
+    private func processEvent(event: FileSystemEvent) {
+        FileSystemWatcher.log("\t\(event.id) - \(event.flags) - \(event.path)")
+        self.callback(event)
+    }
+    
+    /// Prints the message when in debug mode.
+    ///
+    /// - Parameter message: The message to be logged.
+    private static func log(message: String) {
+        #if DEBUG
+            print(message)
+        #endif
+    }
+    
+    // MARK: - Methods
+    
+    // Start watching by creating the stream
+    /// Starts watching.
+    public func watch() {
+        guard started == false else { return }
+        
+        var context = FSEventStreamContext(
+            version: 0,
+            info: nil,
+            retain: nil,
+            release: nil,
+            copyDescription: nil
+        )
+        // add self into context
+        context.info = UnsafeMutablePointer<Void>(unsafeAddressOf(self))
+        
+        let streamRef = FSEventStreamCreate(
+            kCFAllocatorDefault,
+            FileSystemWatcher.eventCallback,
+            &context,
+            paths.map {$0.rawValue},
+            // since when
+            lastEventId,
+            // how long to wait after an event occurs before forwarding it
+            latency,
+            UInt32(flags.rawValue)
+        )
+        stream = FileSystemEventStream(rawValue: streamRef)
+        
+        stream?.scheduleWithRunLoop(runLoop, runLoopMode: runLoopMode)
+        if let q = queue {
+            stream?.setDispatchQueue(q)
+        }
+        stream?.start()
+        
+        started = true
+    }
+    
+    // Stops, invalidates and releases the stream
+    /// Closes the watcher.
+    public func close() {
+        guard started == true else { return }
+        
+        stream?.stop()
+        stream?.invalidate()
+        stream?.release()
+        stream = nil
+        
+        started = false
+    }
+    
+    /// Requests that the fseventsd daemon send any events it has already
+    /// buffered (via the latency parameter).
+    ///
+    /// This occurs asynchronously; clients will not have received all the
+    /// callbacks by the time this call returns to them.
+    public func flushAsync() {
+        stream?.flushAsync()
+    }
+    
+    /// Requests that the fseventsd daemon send any events it has already
+    /// buffered (via the latency). Then runs the runloop in its private mode
+    /// till all events that have occurred have been reported (via the client's
+    /// callback).
+    ///
+    /// This occurs synchronously; clients will have received all the callbacks
+    /// by the time this call returns to them.
+    public func flushSync() {
+        stream?.flushSync()
+    }
+    
+}
+    
+#endif

--- a/FileKit/Core/FileType.swift
+++ b/FileKit/Core/FileType.swift
@@ -52,6 +52,8 @@ public enum FileType: String {
     case Unknown
 
     /// Creates a FileType from an `NSFileType` attribute.
+    ///
+    /// - Parameter rawValue: The raw value to create from.
     public init?(rawValue: String) {
         switch rawValue {
         case NSFileTypeDirectory:

--- a/FileKit/Core/Operators.swift
+++ b/FileKit/Core/Operators.swift
@@ -25,6 +25,8 @@
 //  THE SOFTWARE.
 //
 
+// swiftlint:disable file_length
+
 import Foundation
 
 // MARK: - File

--- a/FileKit/Core/Operators.swift
+++ b/FileKit/Core/Operators.swift
@@ -70,7 +70,8 @@ infix operator |>> {}
 ///
 /// - Throws: `FileKitError.WriteToFileFail`
 ///
-public func |>> (var data: String, file: TextFile) throws {
+public func |>> (data: String, file: TextFile) throws {
+    var data = data
     if let contents = try? file.read() {
         data = contents + "\n" + data
     }

--- a/FileKit/Core/Path.swift
+++ b/FileKit/Core/Path.swift
@@ -507,6 +507,8 @@ extension Path {
     // MARK: - RawRepresentable
 
     /// Initializes a path to the string value.
+    ///
+    /// - Parameter rawValue: The raw value to initialize from.
     public init(rawValue: String) {
         self.rawValue = rawValue
     }
@@ -685,6 +687,9 @@ extension Path {
 
     // MARK: - NSURL
 
+    /// Creates a new path with given url if possible.
+    ///
+    /// - Parameter url: The url to create a path for.
     public init?(url: NSURL) {
         guard let path = url.path where url.fileURL else {
             return nil
@@ -692,6 +697,7 @@ extension Path {
         rawValue = path
     }
 
+    /// - Returns: The `Path` objects url.
     public var url: NSURL {
         return NSURL(fileURLWithPath: rawValue, isDirectory: self.isDirectory)
     }
@@ -702,6 +708,9 @@ extension Path {
 
     // MARK: - BookmarkData
 
+    /// Creates a new path with given url if possible.
+    ///
+    /// - Parameter bookmarkData: The bookmark data to create a path for.
     public init?(bookmarkData bookData: NSData) {
         var isStale: ObjCBool = false
         let url = try? NSURL(
@@ -715,6 +724,7 @@ extension Path {
         self.init(url: fullURL)
     }
 
+    /// - Returns: The `Path` objects bookmarkData.
     public var bookmarkData: NSData? {
         return try? url.bookmarkDataWithOptions(
             .SuitableForBookmarkFile,
@@ -729,6 +739,8 @@ extension Path {
     // MARK: - SecurityApplicationGroupIdentifier
 
     /// Returns the container directory associated with the specified security application group ID.
+    ///
+    /// - Parameter groupIdentifier: The group identifier.
     public init?(groupIdentifier: String) {
         guard let url = NSFileManager().containerURLForSecurityApplicationGroupIdentifier(groupIdentifier) else {
             return nil
@@ -832,7 +844,7 @@ extension Path: SequenceType {
 
     // MARK: - SequenceType
 
-    /// Return a *generator* over the contents of the path.
+    /// - Returns: A *generator* over the contents of the path.
     public func generate() -> DirectoryEnumerator {
         return DirectoryEnumerator(path: self)
     }

--- a/FileKit/Core/Path.swift
+++ b/FileKit/Core/Path.swift
@@ -263,14 +263,13 @@ extension Path {
 
         let total = Swift.min(selfComponents.count, pathComponents.count)
 
-        var index = 0
-        for index = 0; index < total; ++index {
+        for index in 0..<total {
             if selfComponents[index].rawValue != pathComponents[index].rawValue {
                 break
             }
         }
 
-        let ancestorComponents = selfComponents[0..<index]
+        let ancestorComponents = selfComponents[0..<total]
         return ancestorComponents.reduce("") { $0 + $1 }
     }
 

--- a/FileKit/Core/TextFile.swift
+++ b/FileKit/Core/TextFile.swift
@@ -36,12 +36,17 @@ public class TextFile: File<String> {
     public var encoding: NSStringEncoding
 
     /// Initializes a text file from a path.
+    ///
+    /// - Parameter path: The path to be created a text file from.
     public override init(path: Path) {
         self.encoding = NSUTF8StringEncoding
         super.init(path: path)
     }
 
     /// Initializes a text file from a path with an encoding.
+    ///
+    /// - Parameter path: The path to be created a text file from.
+    /// - Parameter encoding: The encoding to be used for the text file.
     public init(path: Path, encoding: NSStringEncoding) {
         self.encoding = encoding
         super.init(path: path)
@@ -111,9 +116,13 @@ extension TextFile {
 /// A class to read `TextFile` line by line.
 public class TextFileStreamReader {
 
+    /// The text encoding.
     public let encoding: NSStringEncoding
+    
+    /// The chunk size when reading.
     public let chunkSize: Int
 
+    /// Tells if the position is at the end of file.
     public var atEOF: Bool = false
 
     let fileHandle: NSFileHandle!
@@ -156,14 +165,14 @@ public class TextFileStreamReader {
 
     // MARK: - public methods
 
-    /// Return next line, or nil on EOF.
+    /// - Returns: The next line, or nil on EOF.
     public func nextLine() -> String? {
         if atEOF {
             return nil
         }
 
         // Read data chunks from file until a line delimiter is found.
-        var range = buffer.rangeOfData(delimData, options: [], range: NSMakeRange(0, buffer.length))
+        var range = buffer.rangeOfData(delimData, options: [], range: NSRange(location: 0, length: buffer.length))
         while range.location == NSNotFound {
             let tmpData = fileHandle.readDataOfLength(chunkSize)
             if tmpData.length == 0 {
@@ -180,14 +189,14 @@ public class TextFileStreamReader {
                 return nil
             }
             buffer.appendData(tmpData)
-            range = buffer.rangeOfData(delimData, options: [], range: NSMakeRange(0, buffer.length))
+            range = buffer.rangeOfData(delimData, options: [], range: NSRange(location: 0, length: buffer.length))
         }
 
         // Convert complete line (excluding the delimiter) to a string.
-        let line = NSString(data: buffer.subdataWithRange(NSMakeRange(0, range.location)),
+        let line = NSString(data: buffer.subdataWithRange(NSRange(location: 0, length: range.location)),
             encoding: encoding)
         // Remove line (and the delimiter) from the buffer.
-        let cleaningRange = NSMakeRange(0, range.location + range.length)
+        let cleaningRange = NSRange(location: 0, length: range.location + range.length)
         buffer.replaceBytesInRange(cleaningRange, withBytes: nil, length: 0)
 
         return line as? String
@@ -209,6 +218,7 @@ public class TextFileStreamReader {
 
 // Implement `SequenceType` for `TextFileStreamReader`
 extension TextFileStreamReader : SequenceType {
+    /// - Returns: A generator to be used for iterating over a `TextFileStreamReader` object.
     public func generate() -> AnyGenerator<String> {
         return AnyGenerator {
             return self.nextLine()

--- a/FileKit/Core/TextFile.swift
+++ b/FileKit/Core/TextFile.swift
@@ -210,7 +210,7 @@ public class TextFileStreamReader {
 // Implement `SequenceType` for `TextFileStreamReader`
 extension TextFileStreamReader : SequenceType {
     public func generate() -> AnyGenerator<String> {
-        return anyGenerator {
+        return AnyGenerator {
             return self.nextLine()
         }
     }

--- a/FileKit/Extensions/Image+FileKit.swift
+++ b/FileKit/Extensions/Image+FileKit.swift
@@ -45,6 +45,7 @@ extension Image: DataType, WritableConvertible {
 
     /// Returns an image from the given path.
     ///
+    /// - Parameter path: The path to be returned the image for.
     /// - Throws: FileKitError.ReadFromFileFail
     ///
     public class func readFromPath(path: Path) throws -> Self {

--- a/FileKit/Extensions/NSArray+FileKit.swift
+++ b/FileKit/Extensions/NSArray+FileKit.swift
@@ -30,6 +30,8 @@ import Foundation
 extension NSArray: DataType, WritableToFile {
 
     /// Returns an array read from the given path.
+    ///
+    /// - Parameter path: The path an array to be read from.
     public class func readFromPath(path: Path) throws -> Self {
         guard let contents = self.init(contentsOfFile: path.rawValue) else {
             throw FileKitError.ReadFromFileFail(path: path)

--- a/FileKitTests/Date+FileKit.swift
+++ b/FileKitTests/Date+FileKit.swift
@@ -27,10 +27,20 @@
 
 import Foundation
 
+/// Checks equality of two `NSDate` objects.
+///
+/// - Parameter lhs: The left hand side of the comparison.
+/// - Parameter rhs: The right hand side of the comparison.
+/// - Returns: `true` if the two objects are equal, otherwise `false`.
 public func == (lhs: NSDate, rhs: NSDate) -> Bool {
     return lhs === rhs || lhs.compare(rhs) == .OrderedSame
 }
 
+/// Compares two `NSDate` objects.
+///
+/// - Parameter lhs: The left hand side of the comparison.
+/// - Parameter rhs: The right hand side of the comparison.
+/// - Returns: `true` if the left hand side is smaller than the right hand side, otherwise `false`.
 public func < (lhs: NSDate, rhs: NSDate) -> Bool {
     return lhs.compare(rhs) == .OrderedAscending
 }

--- a/FileKitTests/FileKitTests.swift
+++ b/FileKitTests/FileKitTests.swift
@@ -126,13 +126,13 @@ class FileKitTests: XCTestCase {
         var i = 0
         let parent = Path.UserTemporary
         for _ in parent {
-            i++
+            i += 1
         }
         print("\(i) files under \(parent)")
 
         i = 0
         for (_, _) in Path.UserTemporary.enumerate() {
-            i++
+            i += 1
         }
     }
 


### PR DESCRIPTION
This fixes Swift 2.2 deprecations warnings (improving compatibility with Swift 3) and also fixes all Swift Linter warnings by configuring it and fixing many warnings in code. See the detailed commit descriptions for additional information.