### PR TITLE
Change Path.touch to accept an optional modificationDate

### DIFF
--- a/Sources/Path.swift
+++ b/Sources/Path.swift
@@ -629,11 +629,9 @@ extension Path {
     ///     `FileKitError.CreateFileFail`,
     ///     `FileKitError.AttributesChangeFail`
     ///
-    public func touch(_ updateModificationDate: Bool = true) throws {
+    public func touch(modificationDate: Date = Date()) throws {
         if self.exists {
-            if updateModificationDate {
-                try _setAttribute(FileAttributeKey.modificationDate, value: Date())
-            }
+            try _setAttribute(FileAttributeKey.modificationDate, value: modificationDate)
         } else {
             try createFile()
         }


### PR DESCRIPTION
Hi! This pull request modifies `Path.touch` so that it accepts an optional modification date rather than a boolean. 

This makes it more similar to using `touch` on the command line (passing in the modification date is like using `touch -t`). I'm using this for a project where I needed to download a bunch of files but preserve a "modified date" that is given as metadata. 