### PR TITLE
Restrict iOS to app extension safe APIs

### DIFF
--- a/FileKit.xcodeproj/project.pbxproj
+++ b/FileKit.xcodeproj/project.pbxproj
@@ -918,6 +918,7 @@
 		5204B85E1B96B85E00AA473F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -938,6 +939,7 @@
 		5204B85F1B96B85E00AA473F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;


### PR DESCRIPTION
This is a requirement for use in app extensions, and is already satisfied so it doesn't appear to actually affect anything.