### PR TITLE
Update Package.swift to API v4.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,4 @@
+// swift-tools-version:4.2
 //
 //  Package.swift
 //  FileKit
@@ -29,7 +30,23 @@ import PackageDescription
 
 let package = Package(
     name: "FileKit",
-    exclude: [
-	"Tests"
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "FileKit",
+            targets: ["FileKit"]),
+    ],
+    dependencies: [],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "FileKit",
+            dependencies: [],
+            path: "Sources"),
+        .testTarget(
+            name: "FileKitTests",
+            dependencies: ["FileKit"],
+            path: "Tests")
     ]
 )


### PR DESCRIPTION
The current format of the `Package.swift` file is not compatible with the Xcode 10.2 toolchain, and produces the following error:

```
error: manifest parse error(s):
/tmp/TemporaryFile.acKJOQ.swift:32:14: error: extra argument 'exclude' in call
    exclude: [
             ^
```

Updating the manifest to use the 4.2 tools fixes the issue, while maintaining compatibility with Xcode 10.1.